### PR TITLE
Add zenodo DOI to data/combinatorial_library/README.md, add reference…

### DIFF
--- a/data/combinatorial_library/README.md
+++ b/data/combinatorial_library/README.md
@@ -2,16 +2,16 @@
 
 This folder is meant for the metadata and properties of the KinFragLib combinatorial library, which is based on the KinFragLib fragment library at https://github.com/volkamerlab/KinFragLib. This dataset is used for the analysis of the combinatorial library.
 
-Since this dataset contains large files, we provide it outside this repository at https://osf.io/cy7tr/.
-In order to run the analysis notebooks, please download this dataset to this folder (as also instructed in the respective notebooks). 
+**Note**: Since this dataset contains large files, we provide it outside this repository at https://zenodo.org/record/3954932 (DOI: 10.5281/zenodo.3954932, v1.0.0).
+In order to run the analysis notebooks, please download this dataset to this folder. 
 
-## Raw data (download from https://osf.io/cy7tr/)
+## Raw data
 
 - `combinatorial_library.json`: Full combinatorial library, please refer to `notebooks/4_1_combinatorial_library_data_preparation.ipynb` at https://github.com/volkamerlab/KinFragLib for detailed information about this data format
 - `combinatorial_library_deduplicated.json`: Deduplicated combinatorial library (based on InChIs)
 - `chembl_standardized_inchi.csv`: Standardized ChEMBL 25 molecules in the form of InChI strings.
 
-## Processed data (download from https://osf.io/cy7tr/)
+## Processed data
 
 Data extracted from `combinatorial_library_deduplicated.json`, performed in `notebooks/4_1_combinatorial_library_data_preparation.ipynb` at https://github.com/volkamerlab/KinFragLib.
 
@@ -23,5 +23,3 @@ Data extracted from `combinatorial_library_deduplicated.json`, performed in `not
 - `original_substructure.json`: Ligands with substructure matches in original ligands, i.e. KLIFS ligands that were used for the fragmentation
 - `chembl_exact.json`: Ligands with exact matches in ChEMBL
 - `chembl_most_similar.json`: Most similar ligand in ChEMBL for each recombined ligand 
-
-

--- a/notebooks/4_1_combinatorial_library_data.ipynb
+++ b/notebooks/4_1_combinatorial_library_data.ipynb
@@ -81,7 +81,8 @@
     "\n",
     "The combinatorial library comes as large `json` file (3.3 GB).\n",
     "\n",
-    "**Note 1**: Due to its size, this file is not included in this GitHub repository but can be downloaded alongside all output files from this notebook from https://osf.io/cy7tr/. Save files to `../data/combinatorial_library/` to run this notebook as-is.\n",
+    "**Note 1**: Due to its size, this file is not included in this GitHub repository but can be downloaded alongside all output files from this notebook from zenodo. \n",
+    "Please follow the instructions given in `../data/combinatorial_library/README.md`.\n",
     "\n",
     "**Note 2**: This notebook prepares data for the subsequent analysis notebooks. Since all output files from this notebook are included in the download, is it not necessary to rerun this notebook (takes about 20 minutes) to continue with the analysis notebooks. "
    ]

--- a/notebooks/4_2_combinatorial_library_properties.ipynb
+++ b/notebooks/4_2_combinatorial_library_properties.ipynb
@@ -18,7 +18,7 @@
     "1. Recombined ligands compliant with Lipinski's rule of five (criteria) in comparison to KLIFS and PKIDB ligands\n",
     "2. Recombined ligand sizes (number of heavy atoms)\n",
     "\n",
-    "**Note** that the combinatorial library is stored as `json` file (6.7M molecules). The data needed for this notebook was extracted previously in notebook `4_1_combinatorial_library_data.ipynb` for easy and fast access here. In order to run this notebook, download data from https://osf.io/cy7tr/ and save files to `../data/combinatorial_library/`. "
+    "**Note** that the combinatorial library is stored as `json` file (6.7M molecules). The data needed for this notebook was extracted previously in notebook `4_1_combinatorial_library_data.ipynb` for easy and fast access here. In order to run this notebook, download data from zenodo as instructed in `../data/combinatorial_library/README.md`."
    ]
   },
   {

--- a/notebooks/4_3_combinatorial_library_comparison_klifs.ipynb
+++ b/notebooks/4_3_combinatorial_library_comparison_klifs.ipynb
@@ -18,7 +18,7 @@
     "1. Which recombined ligands have exact matches in the original KLIFS ligands?\n",
     "2. Which recombined ligands have substructure matches in the original KLIFS ligands?\n",
     "\n",
-    "**Note** that the combinatorial library is stored as `json` file (6.7M molecules). The data needed for this notebook was extracted previously in notebook `4_1_combinatorial_library_data.ipynb` for easy and fast access here. In order to run this notebook, download data from https://osf.io/cy7tr/ and save files to `../data/combinatorial_library/`. "
+    "**Note** that the combinatorial library is stored as `json` file (6.7M molecules). The data needed for this notebook was extracted previously in notebook `4_1_combinatorial_library_data.ipynb` for easy and fast access here. In order to run this notebook, download data from zenodo as instructed in `../data/combinatorial_library/README.md`."
    ]
   },
   {

--- a/notebooks/4_4_combinatorial_library_comparison_chembl.ipynb
+++ b/notebooks/4_4_combinatorial_library_comparison_chembl.ipynb
@@ -18,7 +18,7 @@
     "1. How similar are recombined ligands to ChEMBL ligands?\n",
     "2. Which recombined ligands have exact matches in ChEMBL?\n",
     "\n",
-    "**Note** that the combinatorial library is stored as `json` file (6.7M molecules). The data needed for this notebook was extracted previously in notebook `4_1_combinatorial_library_data.ipynb` for easy and fast access here. In order to run this notebook, download data from https://osf.io/cy7tr/ and save files to `../data/combinatorial_library/`. "
+    "**Note** that the combinatorial library is stored as `json` file (6.7M molecules). The data needed for this notebook was extracted previously in notebook `4_1_combinatorial_library_data.ipynb` for easy and fast access here. In order to run this notebook, download data from zenodo as instructed in `../data/combinatorial_library/README.md`."
    ]
   },
   {


### PR DESCRIPTION
## Description

Add zenodo DOI to `data/combinatorial_library/README.md` and add reference to this `README` to all `4_*...` notebooks.

## ToDos

 - [x] Add zenodo DOI for combinatorial library to `data/combinatorial_library/README.md`
 - [x] Add reference in all `4_*...` notebooks (do not add zenodo DOI to each notebook for easier maintenance - this way we only need to update one file (`data/combinatorial_library/README.md`) if case of newer versions of this dataset

## Questions

 - [x] Which external data deposition platform to use? zenodo

## Status

 - [x] Ready to go