### PR TITLE
Add kinfraglib filters module (skeleton)

### DIFF
--- a/kinfraglib/filters/plots.py
+++ b/kinfraglib/filters/plots.py
@@ -1,0 +1,3 @@
+"""
+Contains plotting functionalities for different filters.
+"""

--- a/kinfraglib/filters/syba.py
+++ b/kinfraglib/filters/syba.py
@@ -1,0 +1,3 @@
+"""
+Contains the SYBA filter.
+"""


### PR DESCRIPTION
## Description
Add a first skeleton for Custom-KinFragLib filters (could also become the home of existing filters, e.g. Ro3, living currently in `kinfraglib.utils`).

## Todos
  - [ ] Add `kinfraglib.filters`
  - [ ] Add `kinfraglib.filters.syba` skeleton submodule
  - [ ] Add `kinfraglib.filters.plots` skeleton submodule that shall contain generalized plotting function for the different filters

## Questions
- [ ] Question1

## Status
- [ ] Ready to go