### PR TITLE
Test: CI on Python 3.7 and 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,15 +20,9 @@ jobs:
       matrix:
         cfg:
           - os: ubuntu-latest
-            python-version: "3.6"
+            python-version: "3.7"
           - os: ubuntu-latest
-            python-version: "3.8"
-          #- os: ubuntu-latest
-          #  python-version: "3.9"
-          #- os: macos-latest
-          #  python-version: "3.6"
-          #- os: windows-latest
-          #  python-version: "3.6"
+            python-version: "3.9"
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
## Description
Test if CI runs on Python 3.7 and 3.9.

## Todos
  - [ ] Update GHA workflow

## Questions
None.

## Status
- [ ] Ready to go