### PR TITLE
CI support: Replace Python 3.6 with 3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,13 +33,17 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      # More info on options: https://github.com/conda-incubator/setup-miniconda
       - uses: conda-incubator/setup-miniconda@v2
         with:
           python-version: ${{ matrix.cfg.python-version }}
-          activate-environment: kinfraglib
-          channel-priority: true
+          mamba-version: "*"
           environment-file: environment.yml
+          channels: conda-forge,defaults
+          activate-environment: kinfraglib
+          auto-update-conda: false
           auto-activate-base: false
+          show-channel-urls: true
 
       - name: Additional info about the build
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         cfg:
           - os: ubuntu-latest
-            python-version: "3.6"
+            python-version: "3.7"
           - os: ubuntu-latest
             python-version: "3.8"
           #- os: ubuntu-latest


### PR DESCRIPTION
## Description
CI got disabled; try to trigger CI with this PR.

## Todos
- [x] Change Python 3.6 to 3.7 (under 3.6 we have a ´from __future__ import annotations´ syntax error (`biopandas`) because this is only available from Python 3.7)

## Status
- [ ] Ready to go