### PR TITLE
CI fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,13 +22,13 @@ jobs:
       matrix:
         cfg:
           - os: ubuntu-latest
-            python-version: "3.9"
-          - os: ubuntu-latest
             python-version: "3.8"
           - os: ubuntu-latest
-            python-version: "3.11"
-          #- os: macos-latest
-          #  python-version: "3.10"
+            python-version: "3.9"
+          # - os: ubuntu-latest
+          #  python-version: "3.11"
+          - os: macos-latest
+            python-version: "3.9"
           #- os: windows-latest
           #  python-version: "3.6"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,14 +21,14 @@ jobs:
       fail-fast: false
       matrix:
         cfg:
-          - os: ubuntu-latest
-            python-version: "3.7"
+          #- os: ubuntu-latest
+          #  python-version: "3.7"
           - os: ubuntu-latest
             python-version: "3.8"
-          #- os: ubuntu-latest
-          #  python-version: "3.9"
-          #- os: macos-latest
-          #  python-version: "3.6"
+          - os: ubuntu-latest
+            python-version: "3.11"
+          - os: macos-latest
+            python-version: "3.10"
           #- os: windows-latest
           #  python-version: "3.6"
 
@@ -39,13 +39,15 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         with:
           python-version: ${{ matrix.cfg.python-version }}
-          mamba-version: "*"
+          #mamba-version: "*"
+          miniforge-variant: Mambaforge
+          miniforge-version: latest
           environment-file: environment.yml
           channels: conda-forge,defaults
           activate-environment: kinfraglib
-          auto-update-conda: false
-          auto-activate-base: false
-          show-channel-urls: true
+          #auto-update-conda: false
+          #auto-activate-base: false
+          #show-channel-urls: true
 
       - name: Additional info about the build
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           #  python-version: "3.6"
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       # More info on options: https://github.com/conda-incubator/setup-miniconda
       - uses: conda-incubator/setup-miniconda@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,8 @@ jobs:
             python-version: "3.8"
           - os: ubuntu-latest
             python-version: "3.9"
-          - os: macos-latest
-            python-version: "3.9"
+          #- os: macos-latest
+          #  python-version: "3.9"
           #- os: windows-latest
           #  python-version: "3.9"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,6 @@ jobs:
       - name: Run tests
         shell: bash -l {0}
         run: |
-          PYTEST_ARGS="--nbval-lax --current-env --nbval-cell-timeout=900"
+          PYTEST_ARGS="--nbval-lax --current-env --nbval-cell-timeout=1800"
           pytest $PYTEST_ARGS
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v4
 
       # More info on options: https://github.com/conda-incubator/setup-miniconda
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           python-version: ${{ matrix.cfg.python-version }}
           #mamba-version: "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
         shell: bash -l {0}
         run: |
           echo "Download combinatorial library from zenodo..."
-          wget -q -O data/combinatorial_library/combinatorial_library.tar.bz2 https://zenodo.org/record/3956580/files/combinatorial_library.tar.bz2?download=1
+          wget -q -O data/combinatorial_library/combinatorial_library.tar.bz2 https://zenodo.org/record/10843763/files/combinatorial_library.tar.bz2?download=1
           ls -l data/combinatorial_library/
           echo "Decompress selected files..."
           tar -xvf data/combinatorial_library/combinatorial_library.tar.bz2 combinatorial_library_deduplicated.json chembl_standardized_inchi.csv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,12 +25,10 @@ jobs:
             python-version: "3.8"
           - os: ubuntu-latest
             python-version: "3.9"
-          # - os: ubuntu-latest
-          #  python-version: "3.11"
           - os: macos-latest
             python-version: "3.9"
-          - os: windows-latest
-            python-version: "3.9"
+          #- os: windows-latest
+          #  python-version: "3.9"
 
     steps:
       - uses: actions/checkout@v4
@@ -39,7 +37,6 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v3
         with:
           python-version: ${{ matrix.cfg.python-version }}
-          #mamba-version: "*"
           miniforge-variant: Mambaforge
           miniforge-version: latest
           environment-file: environment.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,8 @@ jobs:
             python-version: "3.8"
           - os: ubuntu-latest
             python-version: "3.11"
-          - os: macos-latest
-            python-version: "3.10"
+          #- os: macos-latest
+          #  python-version: "3.10"
           #- os: windows-latest
           #  python-version: "3.6"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,8 @@ jobs:
           #  python-version: "3.11"
           - os: macos-latest
             python-version: "3.9"
-          #- os: windows-latest
-          #  python-version: "3.6"
+          - os: windows-latest
+            python-version: "3.9"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,6 @@ jobs:
       - name: Run tests
         shell: bash -l {0}
         run: |
-          PYTEST_ARGS="--nbval-lax --current-env --nbval-cell-timeout=1800"
+          PYTEST_ARGS="--nbval-lax --nbval-current-env --nbval-cell-timeout=900"
           pytest $PYTEST_ARGS
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,6 @@ jobs:
       - name: Run tests
         shell: bash -l {0}
         run: |
-          PYTEST_ARGS="--nbval-lax --nbval-current-env --nbval-cell-timeout=900"
+          PYTEST_ARGS="--nbval-lax --nbval-current-env --nbval-cell-timeout=1800"
           pytest $PYTEST_ARGS
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,8 @@ jobs:
       fail-fast: false
       matrix:
         cfg:
-          #- os: ubuntu-latest
-          #  python-version: "3.7"
+          - os: ubuntu-latest
+            python-version: "3.9"
           - os: ubuntu-latest
             python-version: "3.8"
           - os: ubuntu-latest

--- a/environment.yml
+++ b/environment.yml
@@ -26,4 +26,5 @@ dependencies:
   - pip:
     - black-nb
     # KinFragLib itself
-    - https://github.com/volkamerlab/kinfraglib/archive/master.tar.gz
+    # - https://github.com/volkamerlab/kinfraglib/archive/master.tar.gz 
+    - .

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   # Base dependencies
-  - python=3.8
+  - python>=3.8
   - pip
   # Package dependencies
   - biopandas


### PR DESCRIPTION
## Description
Getting the CI running again.

## Todos
  - [x] Updated python version to 3.8 and 3.9
  - [x] Updated conda-incubator/setup-miniconda from v2 -> v3 and actions/checkout v2 -> v4
  - [x] Linked new combinatorial library from zenodo
  - [x] Increased timeout due to increase in combinatorial library size
  - [ ] Add macos to ci (https://github.com/volkamerlab/KinFragLib/issues/28), won't fix now
  - [ ] Add windows to ci (won't fix this now) 
  - [x] environment.yml: change pip install of kinfraglib (same as in teachopencadd)


## Status
- [ ] Ready to go