### PR TITLE
CI fix: Mambaforge deprecated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,6 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v3
         with:
           python-version: ${{ matrix.cfg.python-version }}
-          miniforge-variant: Mambaforge
           miniforge-version: latest
           environment-file: environment.yml
           channels: conda-forge,defaults


### PR DESCRIPTION
## Description
CI is currently failing since Mambaforge is deprecated, swap out for Miniforge in the CI. 

## Todos
  - [x] Swap Mambaforge with Miniforge 


## Status
- [x] Ready to go